### PR TITLE
Improve portability and fix usage of server for common scenarios

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ Options:
 }
 options.port ??= 8000;
 
-const injection = await Bun.file('injection.html').text();
+const injection = await Bun.file(`${import.meta.dir}/injection.html`).text();
 
 let clients = [];
 let watcher = watch(

--- a/index.js
+++ b/index.js
@@ -68,9 +68,10 @@ const server = Bun.serve({
       let content = await file.bytes();
       if (file.type.includes('text/html')) {
         const textDecoder = new TextDecoder();
-        let textContent = textDecoder.decode(content.buffer);
+        let textContent = textDecoder.decode(content);
         let idx = textContent.search(/<\/body>/i);
-        content = ''.concat(textContent.slice(0, idx), injection, textContent.slice(idx));
+        textContent = ''.concat(textContent.slice(0, idx), injection, textContent.slice(idx));
+        return new Response(textContent, { headers: { 'Content-Type': file.type } });
       }
       return new Response(content, { headers: { 'Content-Type': file.type } });
     } else {

--- a/index.js
+++ b/index.js
@@ -68,10 +68,9 @@ const server = Bun.serve({
       let content = await file.bytes();
       if (file.type.includes('text/html')) {
         const textDecoder = new TextDecoder();
-        let textContent = textDecoder.decode(content);
-        let idx = textContent.search(/<\/body>/i);
-        textContent = ''.concat(textContent.slice(0, idx), injection, textContent.slice(idx));
-        return new Response(textContent, { headers: { 'Content-Type': file.type } });
+        content = textDecoder.decode(content);
+        let idx = content.search(/<\/body>/i);
+        content = ''.concat(content.slice(0, idx), injection, content.slice(idx));
       }
       return new Response(content, { headers: { 'Content-Type': file.type } });
     } else {

--- a/index.js
+++ b/index.js
@@ -56,8 +56,14 @@ const server = Bun.serve({
       else return new Response('Failed to upgrade.', { status: 500 });
     }
 
-    let pathname = '.' + new URL(req.url).pathname;
-    let file = Bun.file(pathname);
+    let pathname = new URL(req.url).pathname;
+    // URLs with no set pathname will serve /index.html by default
+    if (pathname === '/') {
+      pathname = "/index.html"
+    }
+
+    let filePath = '.' + pathname;
+    let file = Bun.file(filePath);
     if (await file.exists()) {
       let content = await file.text();
       if (file.type.includes('text/html')) {

--- a/index.js
+++ b/index.js
@@ -65,10 +65,12 @@ const server = Bun.serve({
     let filePath = '.' + pathname;
     let file = Bun.file(filePath);
     if (await file.exists()) {
-      let content = await file.text();
+      let content = await file.bytes();
       if (file.type.includes('text/html')) {
-        let idx = content.search(/<\/body>/i);
-        content = ''.concat(content.slice(0, idx), injection, content.slice(idx));
+        const textDecoder = new TextDecoder();
+        let textContent = textDecoder.decode(content.buffer);
+        let idx = textContent.search(/<\/body>/i);
+        content = ''.concat(textContent.slice(0, idx), injection, textContent.slice(idx));
       }
       return new Response(content, { headers: { 'Content-Type': file.type } });
     } else {

--- a/index.js
+++ b/index.js
@@ -87,6 +87,9 @@ const server = Bun.serve({
       clients = clients.filter((x) => x !== ws);
       console.log(`Disconnected with ${ws.remoteAddress}`);
     },
+    message(ws, code, reason) {
+      
+    }
   },
 });
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const server = Bun.serve({
     let pathname = new URL(req.url).pathname;
     // URLs with no set pathname will serve /index.html by default
     if (pathname === '/') {
-      pathname = "/index.html";
+      pathname = '/index.html';
     }
 
     const filePath = '.' + pathname;

--- a/index.js
+++ b/index.js
@@ -62,8 +62,8 @@ const server = Bun.serve({
       pathname = "/index.html"
     }
 
-    let filePath = '.' + pathname;
-    let file = Bun.file(filePath);
+    const filePath = '.' + pathname;
+    const file = Bun.file(filePath);
     if (await file.exists()) {
       let content = await file.bytes();
       if (file.type.includes('text/html')) {

--- a/index.js
+++ b/index.js
@@ -87,7 +87,7 @@ const server = Bun.serve({
       clients = clients.filter((x) => x !== ws);
       console.log(`Disconnected with ${ws.remoteAddress}`);
     },
-    message(ws, code, reason) {
+    message(ws, message) {
       
     }
   },

--- a/index.js
+++ b/index.js
@@ -34,7 +34,11 @@ options.port ??= 8000;
 const injection = await Bun.file('injection.html').text();
 
 let clients = [];
-let watcher = watch('.');
+let watcher = watch(
+  '.',
+  { recursive: true }
+);
+
 watcher.on('change', (event, filename) => {
   let file = Bun.file(filename.toString());
   if (file.type.includes('text/css')) {

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ const server = Bun.serve({
     let pathname = new URL(req.url).pathname;
     // URLs with no set pathname will serve /index.html by default
     if (pathname === '/') {
-      pathname = "/index.html"
+      pathname = "/index.html";
     }
 
     const filePath = '.' + pathname;


### PR DESCRIPTION
- Listen to file changes from recursive subdirectories
- Injection file is loaded from current directory of script that attempts to load the file
- If request URLs have no set pathname, the server will attempt to serve `/index.html` by default
- Improve handling of non-text files like images. 
  - Provide the response content of served files as bytes by default


