### PR TITLE
Make package executable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env bun
+
 import { watch } from 'fs';
 
 let options = {};

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ for (let i = 2; i < Bun.argv.length; i++) {
   switch (Bun.argv[i]) {
     case '--help':
       console.write(`
-Usage: bun run . [--port PORT] [--help]
+Usage: live-bun [--port PORT] [--help]
 
 Options:
   -p, --port PORT  Specify the port to use. (Default: 8000)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "repository": "github:lumynou5/live-bun",
   "module": "index.js",
   "type": "module",
+  "bin": "index.js",
   "devDependencies": {
     "bun-types": "latest"
   },


### PR DESCRIPTION
Currently, the `index.js` script is not executable so you aren't able to use the package with `bun live-bun` or `live-bun` (if installed globally).

This pull request exposes `index.js` as an executable.